### PR TITLE
Option to disable logging of stdout and stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Dependency Status](https://david-dm.org/gwuhaolin/chrome-runner.svg?style=flat-square)](https://npmjs.org/package/chrome-runner)
 [![Npm Downloads](http://img.shields.io/npm/dm/chrome-runner.svg?style=flat-square)](https://www.npmjs.com/package/chrome-runner)
 
-# chrome-runner 
+# chrome-runner
 Run chrome with ease from node.
 
 - Support OSX Linux Windows system
@@ -34,6 +34,7 @@ await runner.kill();
 - `shouldRestartChrome`: {boole} logger to handle log from chrome-runner, interface like console, default use console
 - `monitorInterval`: {number} in ms, monitor chrome is alive interval, default is 500ms
 - `chromeDataDir`: {string} chrome data dir, default will create one in system tmp
+- `disableLogging`: {boolean} Controls if Chome stdout and stderr is logged to file, default is `true`.
 
 ### Runner API
 - `runner.port`: get chrome remove debug port

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -38,6 +38,7 @@ class Runner extends EventEmitter {
       shouldRestartChrome = true,
       monitorInterval = 500,
       chromeDataDir = makeTmpDir(),
+      disableLogging = false,
     } = opts;
     this.port = port;
     this.chromePath = chromePath;
@@ -46,6 +47,7 @@ class Runner extends EventEmitter {
     this.shouldRestartChrome = shouldRestartChrome;
     this.monitorInterval = monitorInterval;
     this.chromeDataDir = chromeDataDir;
+    this.disableLogging = disableLogging;
 
     this.chromeProcess = undefined;
     this.chromeOutFd = undefined;
@@ -112,7 +114,7 @@ class Runner extends EventEmitter {
     }
     const chromeProcess = childProcess.spawn(this.chromePath, this.flags, {
       detached: true,
-      stdio: ['ignore', this.chromeOutFd, this.chromeErrorFd]
+      stdio: this.disableLogging ? ['ignore', 'ignore', 'ignore'] : ['ignore', this.chromeOutFd, this.chromeErrorFd]
     });
     this.chromeProcess = chromeProcess;
     this.monitorChromeIsAlive();
@@ -158,8 +160,10 @@ class Runner extends EventEmitter {
     if (!fs.existsSync(this.chromeDataDir)) {
       fs.mkdirSync(this.chromeDataDir);
     }
-    this.chromeOutFd = fs.openSync(`${this.chromeDataDir}/chrome-out.log`, 'a');
-    this.chromeErrorFd = fs.openSync(`${this.chromeDataDir}/chrome-err.log`, 'a');
+    if (!this.disableLogging) {
+      this.chromeOutFd = fs.openSync(`${this.chromeDataDir}/chrome-out.log`, 'a');
+      this.chromeErrorFd = fs.openSync(`${this.chromeDataDir}/chrome-err.log`, 'a');
+    }
     this.pidFd = fs.openSync(`${this.chromeDataDir}/chrome.pid`, 'w');
     this.emit('chromeDataDirPrepared', this.chromeDataDir);
   }

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -134,4 +134,13 @@ describe('Runner', function () {
     });
   });
 
+  it.only('set disableLogging option', async function () {
+    const runner = await launchWithHeadless({
+      disableLogging: true,
+    });
+    assert.equal(fs.existsSync(path.join(runner.chromeDataDir, 'chrome-err.log')), false);
+    assert.equal(fs.existsSync(path.join(runner.chromeDataDir, 'chrome-out.log')), false);
+    return await runner.kill();
+  });
+
 });

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -134,7 +134,7 @@ describe('Runner', function () {
     });
   });
 
-  it.only('set disableLogging option', async function () {
+  it('set disableLogging option', async function () {
     const runner = await launchWithHeadless({
       disableLogging: true,
     });


### PR DESCRIPTION
Hi, 

we ran in to a bit of trouble with our `/tmp` disk filling up with the `chrome-error.log`, i.e. 
the stderr logging of the chrome process. 

This PR just adds a new setting, `disableLogging` which just sets stderr and stdout to "ignore". 

Thanks for a really nice library btw :+1: 

Cheers
/david